### PR TITLE
Moving SASS to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,8 @@
     "prettier": "^2.8.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "sass": "^1.63.6",
     "typescript": "^5.1.3"
   },
-  "dependencies": {
-    "sass": "^1.63.6"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Avoid forcing everyone to install SASS as they might not be using it in the final project.