### PR TITLE
Make banner work when re-loaded

### DIFF
--- a/src/components/IubendaCookieSolutionBanner.tsx
+++ b/src/components/IubendaCookieSolutionBanner.tsx
@@ -267,24 +267,32 @@ const IubendaCookieSolutionBanner = ({ config, version }: Props) => {
   useEffect(() => {
     validateConfig(config);
 
-    (window as any)._iub = (window as any)._iub || [];
-    (window as any)._iub.csConfiguration = config;
-    (window as any)._iub.csConfiguration.callback = {
-      onPreferenceExpressedOrNotNeeded: function (preferences: any) {
-        // TODO: Figure out what the "preferences.consent" property really means since it's behavior is not documented.
+    const _iub = ((window as any)._iub = (window as any)._iub || []);
 
-        if (!preferences) {
-          dispatchUserPreferences({ type: 'consent_not_needed' });
+    if (_iub.csReady && _iub.cs?.api.isPreferenceExpressed()) {
+      dispatchUserPreferences({
+        type: 'update',
+        rawData: _iub.cs.consent,
+      });
+    } else {
+      _iub.csConfiguration = config;
+      _iub.csConfiguration.callback = {
+        onPreferenceExpressedOrNotNeeded: function (preferences: any) {
+          // TODO: Figure out what the "preferences.consent" property really means since it's behavior is not documented.
 
-          return;
-        } else {
-          dispatchUserPreferences({
-            type: 'update',
-            rawData: preferences,
-          });
-        }
-      },
-    };
+          if (!preferences) {
+            dispatchUserPreferences({ type: 'consent_not_needed' });
+
+            return;
+          } else {
+            dispatchUserPreferences({
+              type: 'update',
+              rawData: preferences,
+            });
+          }
+        },
+      };
+    }
   }, [config, dispatchUserPreferences]);
 
   return (


### PR DESCRIPTION
My project use `next-intl` for internationalization, and I had to move my `layout.tsx` inside a `[locale]` folder. This is fine in most situation, but when navigating between languages, some cookie dependent features stopped working.

When the current locale is changed, since che layout is inside the `[locale]` folder, all providers are unmounted and mounted again and it turns out that when this is done to the `IubendaProvider` it doesn't work anymore since it loses its internal state.

This PR fixes this issue by checking if the Iubenda scripts are already loaded when the provider is mounted, updating then its internal state with data from the `_iub` object without waiting for the callback, which isn't called at all in this situation.